### PR TITLE
Syntax highlight commands as shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/commands/clean/* linguist-language=Shell

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-/commands/clean/* linguist-language=Shell
+/commands/* linguist-language=Shell


### PR DESCRIPTION
Just to make commands more readable.